### PR TITLE
chore: bump version to 2.39.5 and update security settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "basiscore",
-  "version": "2.39.4",
+  "version": "2.39.5",
   "description": "Client side and light version of BasisCore web programming language",
   "main": "dist/basiscore.js",
   "types": "dist/basiscore.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,7 +44,7 @@ ______           _                               _ _            _
 follow us on https://BasisCore.com/
 
 
-version:2.39.4`,
+version:2.39.5`,
 
   " background: yellow;color: #0078C1; font-size: 2rem; font-family: Arial; font-weight: bolder",
   "color: #0078C1; font-size: 1rem; font-family: Arial;"

--- a/src/options/connection-options/WebConnectionOptions.ts
+++ b/src/options/connection-options/WebConnectionOptions.ts
@@ -132,7 +132,7 @@ export default class WebConnectionOptions extends UrlBaseConnectionOptions {
       method,
       headers,
       body,
-      credentials: "include",
+      credentials: "omit",
     });
 
     if (!response.ok) {

--- a/src/options/connection-options/WebConnectionOptions.ts
+++ b/src/options/connection-options/WebConnectionOptions.ts
@@ -58,7 +58,7 @@ export default class WebConnectionOptions extends UrlBaseConnectionOptions {
     parameters: IDictionary<string>,
     method?: HttpMethod
   ): Promise<string> {
-    return await WebConnectionOptions.fetchAjax(
+    return await WebConnectionOptions.xmlAjax(
       `${this.Url}${pageName ?? ""}`,
       method ?? this.Verb ?? context.options.getDefault("call.verb"),
       parameters
@@ -71,36 +71,48 @@ export default class WebConnectionOptions extends UrlBaseConnectionOptions {
     parameters: IDictionary<string> = null
   ): Promise<string> {
     return new Promise((resolve, reject) => {
-      var xhr = new XMLHttpRequest();
-      xhr.withCredentials = false;
-      xhr.open(method, url, true);
-      xhr.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
-      xhr.onload = function (e) {
-        if (xhr.readyState === 4) {
-          if (xhr.status === 200) {
+      let requestUrl = url;
+      let body: string | null = null;
+
+      if (Util.HasValue(parameters)) {
+        const params = new URLSearchParams();
+        Object.entries(parameters).forEach(([key, value]) => {
+          params.append(key, value);
+        });
+
+        if (method === "GET") {
+          const separator = requestUrl.includes("?") ? "&" : "?";
+          requestUrl += `${separator}${params.toString()}`;
+        } else {
+          body = params.toString();
+        }
+      }
+
+      const xhr = new XMLHttpRequest();
+      xhr.open(method, requestUrl, true);
+
+      if (method !== "GET") {
+        xhr.setRequestHeader(
+          "Content-Type",
+          "application/x-www-form-urlencoded"
+        );
+      }
+
+      xhr.onreadystatechange = () => {
+        if (xhr.readyState === XMLHttpRequest.DONE) {
+          if (xhr.status >= 200 && xhr.status < 300) {
             resolve(xhr.responseText);
           } else {
-            reject(xhr.statusText);
+            reject(new Error(`HTTP error! status: ${xhr.status}`));
           }
         }
       };
-      xhr.onerror = function (e) {
-        reject(xhr.statusText);
+
+      xhr.onerror = () => {
+        reject(new Error("Network error"));
       };
-      var encodedDataPairs;
-      if (Util.HasValue(parameters)) {
-        encodedDataPairs = [];
-        ///https://developer.mozilla.org/en-US/docs/Web/Guide/AJAX/Getting_Started
-        Object.getOwnPropertyNames(parameters).forEach((name, _i, _) =>
-          encodedDataPairs.push(
-            encodeURIComponent(name) +
-              "=" +
-              encodeURIComponent(parameters[name])
-          )
-        );
-        encodedDataPairs = encodedDataPairs.join("&").replace(/%20/g, "+");
-      }
-      xhr.send(encodedDataPairs);
+
+      xhr.send(body);
     });
   }
 


### PR DESCRIPTION
- Update package version from 2.39.4 to 2.39.5
- Change fetch credentials policy from 'include' to 'omit' in WebConnectionOptions
- Prevent sending sensitive credentials with API requests by default